### PR TITLE
レビュー用

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,10 +24,18 @@ Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
+Metrics/ModuleLength:
+  Max: 106
 Metrics/ParameterLists:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Naming/MethodName:
+  Exclude:
+    - "lib/ridgepole/ext/abstract_mysql_adapter/schema_creation.rb"
+Naming/MethodParameterName:
+  Exclude:
+    - "lib/ridgepole/ext/abstract_mysql_adapter/schema_creation.rb"
 Style/Documentation:
   Enabled: false
 Style/GuardClause:

--- a/README.md
+++ b/README.md
@@ -301,6 +301,31 @@ Apply `Schemafile`
 ...
 ```
 
+## Partitioning
+
+**Notice:** PostgreSQL `PARTITION BY` must be specified with the create_table option.
+
+### List Partitioning
+
+```ruby
+create_table "articles", force: :cascade, options: "PARTITION BY LIST(id)" do |t|
+end
+
+add_partition("articles", :list, :id, partition_definitions: [{ name: 'p0', values: { in: [0,1,2] } }, { name: 'p1', values: { in: [3,4,5] } }])
+```
+
+### Range Partitioning
+
+```ruby
+create_table "articles", force: :cascade, options: "PARTITION BY RANGE(id)" do |t|
+end
+
+# postgresql
+add_partition("articles", :range, :id, partition_definitions: [{ name: 'p0', values: { from: 'MINVALUE', to: 5 }}, { name: 'p1', values: { from: 5, to: 10 } }])
+# mysql
+add_partition("articles", :range, :id, partition_definitions: [{ name: 'p0', values: { to: 5 }}, { name: 'p1', values: { to: 10 } }])
+```
+
 ## Run tests
 
 ```sh

--- a/lib/ridgepole.rb
+++ b/lib/ridgepole.rb
@@ -16,6 +16,9 @@ require 'diffy'
 module Ridgepole; end
 
 require 'ridgepole/ext/abstract_adapter/disable_table_options'
+require 'ridgepole/ext/abstract_adapter/partition_definition'
+require 'ridgepole/ext/abstract_adapter/partition_options'
+require 'ridgepole/ext/abstract_adapter/partitioning'
 require 'ridgepole/ext/pp_sort_hash'
 require 'ridgepole/ext/schema_dumper'
 require 'ridgepole/client'

--- a/lib/ridgepole/client.rb
+++ b/lib/ridgepole/client.rb
@@ -15,7 +15,12 @@ module Ridgepole
       @parser = Ridgepole::DSLParser.new(@options)
       @diff = Ridgepole::Diff.new(@options)
 
+      if Ridgepole::ConnectionAdapters.mysql?
+        require 'ridgepole/ext/abstract_mysql_adapter/partitioning'
+        require 'ridgepole/ext/abstract_mysql_adapter/schema_creation'
+      end
       require 'ridgepole/ext/abstract_mysql_adapter/dump_auto_increment' if @options[:mysql_dump_auto_increment]
+      require 'ridgepole/ext/postgresql_adapter/partitioning' if Ridgepole::ConnectionAdapters.postgresql?
     end
 
     def dump(&block)

--- a/lib/ridgepole/delta.rb
+++ b/lib/ridgepole/delta.rb
@@ -310,11 +310,29 @@ execute "ALTER TABLE #{ActiveRecord::Base.connection.quote_table_name(table_name
       append_change_table_options(table_name, comment_literal, buf)
     end
 
+    def append_change_partition(table_name, delta, buf)
+      (delta[:add] || {}).each do |_, attrs|
+        buf.puts "create_partition #{table_name.inspect}, #{attrs.inspect}"
+      end
+    end
+
+    def append_change_partition_definitions(table_name, partition_definitions, buf, _post_buf_for_fk)
+      (partition_definitions[:add] || []).each do |partition_name, attrs|
+        buf.puts "add_partition #{table_name.inspect}, name: #{partition_name.inspect}, values: #{attrs[:values].inspect}"
+      end
+
+      (partition_definitions[:delete] || []).each do |partition_name, _attrs|
+        buf.puts "remove_partition #{table_name.inspect}, name: #{partition_name.inspect}"
+      end
+    end
+
     def append_change(table_name, attrs, buf, pre_buf_for_fk, post_buf_for_fk)
       definition = attrs[:definition] || {}
       primary_key_definition = attrs[:primary_key_definition] || {}
       indices = attrs[:indices] || {}
       foreign_keys = attrs[:foreign_keys] || {}
+      partition = attrs[:partition] || {}
+      partition_definitions = attrs[:partition_definitions] || {}
       table_options = attrs[:table_options]
       table_charset = attrs[:table_charset]
       table_collation = attrs[:table_collation]
@@ -334,6 +352,10 @@ execute "ALTER TABLE #{ActiveRecord::Base.connection.quote_table_name(table_name
       append_change_table_raw_options(table_name, table_options, table_charset, table_collation, buf) if table_options || table_charset || table_collation
 
       append_change_table_comment(table_name, table_comment, buf) if table_comment
+
+      append_change_partition(table_name, partition, buf) unless partition.empty?
+
+      append_change_partition_definitions(table_name, partition_definitions, buf, post_buf_for_fk) unless partition_definitions.empty?
 
       buf.puts
       pre_buf_for_fk.puts

--- a/lib/ridgepole/dsl_parser/context.rb
+++ b/lib/ridgepole/dsl_parser/context.rb
@@ -91,6 +91,22 @@ module Ridgepole
         }
       end
 
+      def add_partition(table_name, type, columns, partition_definitions: [])
+        partition_definitions.each do |partition_definition|
+          values = partition_definition.fetch(:values)
+          raise ArgumentError unless values.is_a?(Hash)
+
+          values[:in] = Array.wrap(values[:in]) if values.key?(:in)
+          values[:to] = Array.wrap(values[:to]) if values.key?(:to)
+          values[:from] = Array.wrap(values[:from]) if values.key?(:from)
+        end
+        @__definition[table_name][:partition] = {
+          type: type,
+          columns: Array.wrap(columns),
+          partition_definitions: partition_definitions,
+        }
+      end
+
       def require(file)
         schemafile = %r{\A/}.match?(file) ? file : File.join(@__working_dir, file)
 

--- a/lib/ridgepole/ext/abstract_adapter/partition_definition.rb
+++ b/lib/ridgepole/ext/abstract_adapter/partition_definition.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'active_record/connection_adapters/abstract_adapter'
+
+module ActiveRecord
+  module ConnectionAdapters
+    class PartitionDefinition
+      attr_reader :name, :values
+
+      def initialize(
+        name,
+        values
+      )
+        @name = name
+        @values = values
+      end
+    end
+  end
+end

--- a/lib/ridgepole/ext/abstract_adapter/partition_options.rb
+++ b/lib/ridgepole/ext/abstract_adapter/partition_options.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'active_record/connection_adapters/abstract_adapter'
+
+module ActiveRecord
+  module ConnectionAdapters
+    class PartitionOptions
+      attr_reader :table, :type, :columns, :partition_definitions
+
+      TYPES = %i[range list].freeze
+
+      def initialize(
+        table, type,
+        columns,
+        partition_definitions: []
+      )
+        @table = table
+        @type = type
+        @columns = Array.wrap(columns)
+        @partition_definitions = build_definitions(partition_definitions)
+      end
+
+      private
+
+      def build_definitions(definitions)
+        definitions.map do |definition|
+          next if definition.is_a?(PartitionDefinition)
+
+          PartitionDefinition.new(definition.fetch(:name), definition.fetch(:values))
+        end.compact
+      end
+    end
+  end
+end

--- a/lib/ridgepole/ext/abstract_adapter/partitioning.rb
+++ b/lib/ridgepole/ext/abstract_adapter/partitioning.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'active_record/connection_adapters/abstract_adapter'
+
+module Ridgepole
+  module Ext
+    module AbstractAdapter
+      module Partitioning
+        def partition(*)
+          nil
+        end
+
+        def partition_tables
+          []
+        end
+
+        # SchemaStatements
+        def create_partition(*)
+          raise NotImplementedError
+        end
+
+        def add_partition(*)
+          raise NotImplementedError
+        end
+
+        def remove_partition(*)
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class AbstractAdapter
+      prepend Ridgepole::Ext::AbstractAdapter::Partitioning
+    end
+  end
+end

--- a/lib/ridgepole/ext/abstract_mysql_adapter/partitioning.rb
+++ b/lib/ridgepole/ext/abstract_mysql_adapter/partitioning.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'active_record/connection_adapters/abstract_mysql_adapter'
+
+module Ridgepole
+  module Ext
+    module AbstractMysqlAdapter
+      module Partitioning
+        def partition(table_name)
+          scope = quoted_scope(table_name)
+
+          partition_info = exec_query(<<~SQL, 'SCHEMA')
+            SELECT PARTITION_NAME, PARTITION_DESCRIPTION, PARTITION_METHOD, PARTITION_EXPRESSION
+            FROM information_schema.partitions
+            WHERE partition_name IS NOT NULL
+              AND table_schema = #{scope[:schema]}
+              AND table_name = #{scope[:name]}
+          SQL
+          return if partition_info.count == 0
+
+          type = case partition_info.first['PARTITION_METHOD']
+                 when 'LIST COLUMNS'
+                   :list
+                 when 'RANGE COLUMNS'
+                   :range
+                 else
+                   raise NotImplementedError, partition_info.first['PARTITION_METHOD'].to_s
+                 end
+          columns = partition_info.first['PARTITION_EXPRESSION'].delete('`').split(',').map(&:to_sym)
+
+          partition_definitions = partition_info.map do |row|
+            values = case type
+                     when :list
+                       { in: instance_eval("[#{row['PARTITION_DESCRIPTION'].gsub(/\(/, '[').gsub(/\)/, ']')}] # [1,2]", __FILE__, __LINE__) }
+                     when :range
+                       { to: instance_eval("[#{row['PARTITION_DESCRIPTION']}] # [1,2]", __FILE__, __LINE__) }
+                     else
+                       raise NotImplementedError
+                     end
+
+            { name: row['PARTITION_NAME'], values: values }
+          end
+
+          ActiveRecord::ConnectionAdapters::PartitionOptions.new(table_name, type, columns, partition_definitions: partition_definitions)
+        end
+
+        # SchemaStatements
+        def create_partition(table_name, type:, columns:, partition_definitions:)
+          execute schema_creation.accept(ActiveRecord::ConnectionAdapters::PartitionOptions.new(table_name, type, columns, partition_definitions: partition_definitions))
+        end
+
+        def add_partition(table_name, name:, values:)
+          pd = ActiveRecord::ConnectionAdapters::PartitionDefinition.new(name, values)
+          execute "ALTER TABLE #{quote_table_name(table_name)} ADD PARTITION (#{schema_creation.accept(pd)})"
+        end
+
+        def remove_partition(table_name, name:)
+          execute "ALTER TABLE #{quote_table_name(table_name)} DROP PARTITION #{name}"
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class AbstractMysqlAdapter < AbstractAdapter
+      prepend Ridgepole::Ext::AbstractMysqlAdapter::Partitioning
+    end
+  end
+end

--- a/lib/ridgepole/ext/abstract_mysql_adapter/schema_creation.rb
+++ b/lib/ridgepole/ext/abstract_mysql_adapter/schema_creation.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'active_record/connection_adapters/mysql/schema_creation'
+
+module Ridgepole
+  module Ext
+    module AbstractMysqlAdapter
+      module SchemaCreation
+        def visit_PartitionOptions(o)
+          sqls = o.partition_definitions.map { |partition_definition| accept partition_definition }
+          function = case o.type
+                     when :list
+                       "LIST COLUMNS(#{o.columns.map { |column| quote_column_name(column) }.join(',')})"
+                     when :range
+                       "RANGE COLUMNS(#{o.columns.map { |column| quote_column_name(column) }.join(',')})"
+                     else
+                       raise NotImplementedError
+                     end
+          "ALTER TABLE #{quote_table_name(o.table)} PARTITION BY #{function} (#{sqls.join(',')})"
+        end
+
+        def visit_PartitionDefinition(o)
+          if o.values.key?(:in)
+            "PARTITION #{o.name} VALUES IN (#{o.values[:in].map do |value|
+              value.is_a?(Array) ? "(#{value.map(&:inspect).join(',')})" : value.inspect
+            end.join(',')})"
+          elsif o.values.key?(:to)
+            "PARTITION #{o.name} VALUES LESS THAN (#{o.values[:to].map(&:inspect).join(',')})"
+          else
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      class SchemaCreation
+        prepend Ridgepole::Ext::AbstractMysqlAdapter::SchemaCreation
+      end
+    end
+  end
+end

--- a/lib/ridgepole/ext/postgresql_adapter/partitioning.rb
+++ b/lib/ridgepole/ext/postgresql_adapter/partitioning.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'active_record/connection_adapters/postgresql_adapter'
+
+module Ridgepole
+  module Ext
+    module PostgreSQLAdapter
+      module Partitioning
+        def supports_partitions?
+          ActiveRecord::VERSION::MAJOR >= 6 && postgresql_version >= 100_000 # >= 10.0
+        end
+
+        def table_options(table_name)
+          options = partition_options(table_name)
+          if options
+            (super || {}).merge(options: "PARTITION BY #{options[:type].to_s.upcase}(#{options[:columns].join(',')})")
+          else
+            super
+          end
+        end
+
+        def partition_options(table_name)
+          return unless supports_partitions?
+
+          scope = quoted_scope(table_name)
+          result = query_value(<<~SQL, 'SCHEMA')
+            SELECT pg_get_partkeydef(t.oid)
+            FROM pg_class t
+              LEFT JOIN pg_namespace n ON n.oid = t.relnamespace
+            WHERE t.relname = #{scope[:name]}
+              AND n.nspname = #{scope[:schema]}
+          SQL
+          return unless result
+
+          type, *columns = result.scan(/\w+/).map { |value| value.downcase.to_sym }
+          { type: type, columns: columns }
+        end
+
+        def partition(table_name)
+          options = partition_options(table_name)
+          return unless options
+
+          scope = quoted_scope(table_name)
+          partition_info = query(<<~SQL, 'SCHEMA')
+            SELECT p.relname, pg_get_expr(p.relpartbound, p.oid, true)
+            FROM pg_class t
+            JOIN pg_inherits i on i.inhparent = t.oid
+            JOIN pg_class p on p.oid = i.inhrelid
+            WHERE t.relname = #{scope[:name]}
+              AND p.relnamespace::regnamespace::text = #{scope[:schema]}
+            ORDER BY p.relname
+          SQL
+
+          partition_definitions = partition_info.map do |row|
+            values = case options[:type]
+                     when :list
+                       values = row[1].match(/FOR VALUES IN \((?<csv>.+)\)$/)[:csv].split(',').map(&:strip).map { |value| cast_value(value) }
+                       { in: Array.wrap(values) }
+                     when :range
+                       match = row[1].match(/FOR VALUES FROM \((?<from>.+)\) TO \((?<to>.+)\)/)
+                       from = match[:from].split(',').map(&:strip).map { |value| cast_value(value) }
+                       to = match[:to].split(',').map(&:strip).map { |value| cast_value(value) }
+                       { from: from, to: to }
+                     else
+                       raise NotImplementedError
+                     end
+            { name: row[0], values: values }
+          end
+
+          ActiveRecord::ConnectionAdapters::PartitionOptions.new(table_name, options[:type], options[:columns], partition_definitions: partition_definitions)
+        end
+
+        def cast_value(value)
+          Integer(value)
+        rescue ArgumentError
+          value.gsub("'", '').gsub('"', '')
+        end
+
+        def quote_value(value)
+          if %w[MINVALUE MAXVALUE].include?(value)
+            value
+          else
+            quote(value)
+          end
+        end
+
+        def partition_tables
+          partition_info = query(<<~SQL, 'SCHEMA')
+            SELECT p.relname
+            FROM pg_class t
+            JOIN pg_inherits i on i.inhparent = t.oid
+            JOIN pg_class p on p.oid = i.inhrelid
+            ORDER BY p.relname
+          SQL
+          partition_info.map { |row| row[0] }
+        end
+
+        # SchemaStatements
+        def add_partition(table_name, name:, values:)
+          condition = if values.key?(:in)
+                        "FOR VALUES IN (#{values[:in].map { |v| quote_value(v) }.join(',')})"
+                      elsif values.key?(:to)
+                        from = values[:from].map { |v| quote_value(v) }.join(',')
+                        to = values[:to].map { |v| quote_value(v) }.join(',')
+                        "FOR VALUES FROM (#{from}) TO (#{to})"
+                      else
+                        raise NotImplementedError
+                      end
+          create_table(name, id: false, options: "PARTITION OF #{table_name} #{condition}")
+        end
+
+        def remove_partition(_table_name, name:)
+          drop_table(name)
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgreSQLAdapter
+      prepend Ridgepole::Ext::PostgreSQLAdapter::Partitioning
+    end
+  end
+end

--- a/spec/mysql/migrate/migrate_add_partition_spec.rb
+++ b/spec/mysql/migrate/migrate_add_partition_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when add list partition' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "list_partitions", id: false, force: :cascade do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "list_partitions", :list, [:id], partition_definitions: [{ name: "list_partitions_p0", values: {:in=>[1]} }]
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "list_partitions", id: false, force: :cascade do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "list_partitions", :list, [:id], partition_definitions: [{ name: "list_partitions_p0", values: {:in=>[1]} } ,{ name: "list_partitions_p1", values: {:in=>[2, 3]} }]
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+
+    it {
+      delta = client(bulk_change: true).diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      expect(delta.script).to match_fuzzy <<-RUBY
+        add_partition "list_partitions", name: "list_partitions_p1", values: {:in=>[2, 3]}
+      RUBY
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+  end
+
+  context 'when add range partition' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "range_partitions", primary_key: ["id", "logdate"], force: :cascade do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "range_partitions", :range, [:logdate], partition_definitions: [{ name: "p0", values: {:to=>["2021-01-01"]} }]
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "range_partitions", primary_key: ["id", "logdate"], force: :cascade do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "range_partitions", :range, [:logdate], partition_definitions: [{ name: "p0", values: {:to=>["2021-01-01"]} }, {name: "p1", values: {:to=>["2022-01-01"]} }]
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+
+    it {
+      delta = client(bulk_change: true).diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      expect(delta.script).to match_fuzzy <<-RUBY
+        add_partition "range_partitions", name: "p1", values: {:to=>["2022-01-01"]}
+      RUBY
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+  end
+
+  context 'when add list partition with multiple columns' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "list_partitions", primary_key: ["id", "name"], force: :cascade do |t|
+          t.integer "id", null: false
+          t.string "name", null: false
+        end
+        add_partition "list_partitions", :list, [:id, :name], partition_definitions: [{ name: "list_partitions_p0", values: {:in=>[[1, "a"]]} }]
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "list_partitions", primary_key: ["id", "name"], force: :cascade do |t|
+          t.integer "id", null: false
+          t.string "name", null: false
+        end
+        add_partition "list_partitions", :list, [:id, :name], partition_definitions: [{ name: "list_partitions_p0", values: {:in=>[[1, "a"]]} } ,{ name: "list_partitions_p1", values: {:in=>[[2, "b"], [3, "c"]]} }]
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+
+    it {
+      delta = client(bulk_change: true).diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      expect(delta.script).to match_fuzzy <<-RUBY
+        add_partition "list_partitions", name: "list_partitions_p1", values: {:in=>[[2, "b"], [3, "c"]]}
+      RUBY
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+  end
+
+  context 'when add range partition with multiple columns' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "range_partitions", primary_key: ["id", "logdate"], force: :cascade do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "range_partitions", :range, [:id, :logdate], partition_definitions: [{ name: "p0", values: {:to=>[1, "2021-01-01"]} }]
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "range_partitions", primary_key: ["id", "logdate"], force: :cascade do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "range_partitions", :range, [:id, :logdate], partition_definitions: [{ name: "p0", values: {:to=>[1, "2021-01-01"]} }, {name: "p1", values: {:to=>[2, "2022-01-01"]} }]
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+
+    it {
+      delta = client(bulk_change: true).diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      expect(delta.script).to match_fuzzy <<-RUBY
+        add_partition "range_partitions", name: "p1", values: {:to=>[2, "2022-01-01"]}
+      RUBY
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+  end
+end

--- a/spec/mysql/migrate/migrate_drop_partition_spec.rb
+++ b/spec/mysql/migrate/migrate_drop_partition_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+describe 'Ridgepole::Client#diff -> migrate' do
+  context 'when add partition' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "list_partitions", id: false, force: :cascade do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "list_partitions", :list, [:id], partition_definitions: [{ name: "list_partitions_p0", values: {:in=>[1]} } ,{ name: "list_partitions_p1", values: {:in=>[2, 3]} }]
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "list_partitions", id: false, force: :cascade do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "list_partitions", :list, [:id], partition_definitions: [{ name: "list_partitions_p0", values: {:in=>[1]} }]
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+
+    it {
+      delta = client(bulk_change: true).diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      expect(delta.script).to match_fuzzy <<-RUBY
+        remove_partition "list_partitions", name: "list_partitions_p1"
+      RUBY
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+  end
+end

--- a/spec/postgresql/migrate/migrate_add_partition_spec.rb
+++ b/spec/postgresql/migrate/migrate_add_partition_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+describe 'Ridgepole::Client#diff -> migrate', condition: '>= 6.0' do
+  after { drop_tables }
+
+  context 'when add list partition' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "list_partitions", id: false, force: :cascade, options: "PARTITION BY LIST(id)" do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "list_partitions", :list, [:id], partition_definitions: [{ name: "list_partitions_p0", values: {:in=>[1]} }]
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "list_partitions", id: false, force: :cascade, options: "PARTITION BY LIST(id)" do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "list_partitions", :list, [:id], partition_definitions: [{ name: "list_partitions_p0", values: {:in=>[1]} } ,{ name: "list_partitions_p1", values: {:in=>[2, 3]} }]
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+
+    it {
+      delta = client(bulk_change: true).diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      expect(delta.script).to match_fuzzy <<-RUBY
+        add_partition "list_partitions", name: "list_partitions_p1", values: {:in=>[2, 3]}
+      RUBY
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+  end
+
+  context 'when add range partition' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "range_partitions", id: false, force: :cascade, options: "PARTITION BY RANGE(logdate)" do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "range_partitions", :range, [:logdate], partition_definitions: [{ name: "p0", values: {:from=>["MINVALUE"], :to=>["2021-01-01"]} }]
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "range_partitions", id: false, force: :cascade, options: "PARTITION BY RANGE(logdate)" do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "range_partitions", :range, [:logdate], partition_definitions: [{ name: "p0", values: {:from=>["MINVALUE"], :to=>["2021-01-01"]} }, {name: "p1", values: {:from=>["2021-01-01"], :to=>["2022-01-01"]} }]
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+
+    it {
+      delta = client(bulk_change: true).diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      expect(delta.script).to match_fuzzy <<-RUBY
+        add_partition "range_partitions", name: "p1", values: {:from=>["2021-01-01"],:to=>["2022-01-01"]}
+      RUBY
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+  end
+
+  context 'when add range partition with multiple columns' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "range_partitions", id: false, options: "PARTITION BY RANGE(id,logdate)", force: :cascade do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "range_partitions", :range, [:id, :logdate], partition_definitions: [{ name: "p0", values: {:from=>[0, "2020-01-01"], :to=>[1, "2021-01-01"]} }]
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "range_partitions", id: false, options: "PARTITION BY RANGE(id,logdate)", force: :cascade do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "range_partitions", :range, [:id, :logdate], partition_definitions: [{ name: "p0", values: {:from=>[0, "2020-01-01"], :to=>[1, "2021-01-01"]} }, {name: "p1", values: {:from=>[1, "2021-01-01"], :to=>[2, "2022-01-01"]} }]
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+
+    it {
+      delta = client(bulk_change: true).diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      expect(delta.script).to match_fuzzy <<-RUBY
+        add_partition "range_partitions", name: "p1", values: {:from=>[1, "2021-01-01"], :to=>[2, "2022-01-01"]}
+      RUBY
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+  end
+end

--- a/spec/postgresql/migrate/migrate_drop_partition_spec.rb
+++ b/spec/postgresql/migrate/migrate_drop_partition_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+describe 'Ridgepole::Client#diff -> migrate', condition: '>= 6.0' do
+  context 'when add partition' do
+    let(:actual_dsl) do
+      erbh(<<-ERB)
+        create_table "list_partitions", id: false, force: :cascade, options: "PARTITION BY LIST(id)"  do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "list_partitions", :list, [:id], partition_definitions: [{ name: "list_partitions_p0", values: {:in=>[1]} } ,{ name: "list_partitions_p1", values: {:in=>[2, 3]} }]
+      ERB
+    end
+
+    let(:expected_dsl) do
+      erbh(<<-ERB)
+        create_table "list_partitions", id: false, force: :cascade, options: "PARTITION BY LIST(id)"  do |t|
+          t.integer "id", null: false
+          t.date "logdate", null: false
+        end
+        add_partition "list_partitions", :list, [:id], partition_definitions: [{ name: "list_partitions_p0", values: {:in=>[1]} }]
+      ERB
+    end
+
+    before { subject.diff(actual_dsl).migrate }
+    subject { client }
+
+    it {
+      delta = subject.diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+
+    it {
+      delta = client(bulk_change: true).diff(expected_dsl)
+      expect(delta.differ?).to be_truthy
+      expect(subject.dump).to match_ruby actual_dsl
+      expect(delta.script).to match_fuzzy <<-RUBY
+        remove_partition "list_partitions", name: "list_partitions_p1"
+      RUBY
+      delta.migrate
+      expect(subject.dump).to match_ruby expected_dsl
+    }
+  end
+end

--- a/spec/postgresql/ridgepole_test_tables_partition.sql
+++ b/spec/postgresql/ridgepole_test_tables_partition.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS list_partitions_p0;
+DROP TABLE IF EXISTS list_partitions_p1;
+DROP TABLE IF EXISTS list_partitions;
+DROP TABLE IF EXISTS range_partitions_p0;
+DROP TABLE IF EXISTS range_partitions_p1;
+DROP TABLE IF EXISTS range_partitions;
+CREATE TABLE list_partitions (id integer not null, logdate date not null) PARTITION BY LIST (id);
+CREATE TABLE list_partitions_p0 PARTITION OF list_partitions FOR VALUES IN(1);
+CREATE TABLE list_partitions_p1 PARTITION OF list_partitions FOR VALUES IN(2,3);
+CREATE TABLE range_partitions (id integer not null, logdate date not null) PARTITION BY RANGE (logdate);
+CREATE TABLE range_partitions_p0 PARTITION OF range_partitions FOR VALUES FROM (MINVALUE) TO ('2021-01-01');
+CREATE TABLE range_partitions_p1 PARTITION OF range_partitions FOR VALUES FROM ('2021-01-01') TO ('2022-01-01');

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,6 +102,16 @@ module SpecHelper
     system_raise_on_fail("#{MYSQL_CLI} < #{sql_file}")
   end
 
+  def restore_tables_postgresql_partition
+    sql_file = File.expand_path('postgresql/ridgepole_test_tables_partition.sql', __dir__)
+    system_raise_on_fail("#{PG_PSQL} ridgepole_test -q -f #{sql_file} 2>/dev/null")
+  end
+
+  def drop_tables
+    connection = ActiveRecord::Base.connection
+    connection.tables.each { |table| connection.drop_table(table, if_exists: true) }
+  end
+
   def client(options = {}, config = {})
     config = conn_spec(config)
     default_options = { debug: condition(:debug) }


### PR DESCRIPTION
# 残り

- [x] spec追加
- [x] timestamp型対応
- [x] string側対応 (動作確認)
- [ ] ridgepole-mysql-partition のような期間、interval 指定パーティション生成の対応

# メモ

- rails の postgresql partition 対応の PR
https://github.com/rails/rails/pull/31336
現状はテーブル一覧でパーティション元のテーブルとパーティションのテーブル両方が取得している状態。
ridgepoleをいまのまま実行するとパーティションテーブルが消える。

- rails に check constraints が入ったときの PR
https://github.com/rails/rails/pull/31323
コミットの粒度（上記PRは１コミット）や、要素追加時の変更範囲の参考に。

- ridgepole では既存のテーブル定義を ActiveRecord::SchemaDumper で取得している

- https://www.postgresql.jp/document/13.0/html/catalog-pg-class.html
```
relkind char

rは通常のテーブル、iはインデックス、Sはシーケンス、tはTOASTテーブル、vはビュー、mはマテリアライズドビュー、cは複合型、fは外部テーブル、pはパーティションテーブル、Iはpartitioned indexを表します。
```

- PostgreSQL のパーティション生成は from, to 指定
https://www.postgresql.org/docs/13/sql-createtable.html

# ridgepole の処理のながれ

- bin/ridgepole
https://github.com/ridgepole/ridgepole/blob/9b657266db2ab938aa146b5995df7363ed732d8b/bin/ridgepole#L233-L255
- client#diff
https://github.com/ridgepole/ridgepole/blob/9b657266db2ab938aa146b5995df7363ed732d8b/lib/ridgepole/client.rb#L27-L39
  - expected_definition, expected_execute  schemaファイルに定義されたもの
  - current_definition, _current_execute databaseからActiveRecord::SchemaDumperで取得した現在の定義
  - @diff.diff(current_definition, expected_definition, execute: expected_execute) で差分作成。戻り値はRidgepole::Delta
https://github.com/ridgepole/ridgepole/blob/0.9/lib/ridgepole/delta.rb